### PR TITLE
Added Google Kickstart

### DIFF
--- a/Opportunity.md
+++ b/Opportunity.md
@@ -10,3 +10,8 @@
   - You have to make 5 PRs in github within the month of october to win exicting goodies and a t-shirt of Hacktoberfest
   - Make sure to register yourself on the given website to be eligible for prizes 
   - It is recommended to make PRs which actually contribute to the project not to just increase your count
+
+### [Google Kickstart](https://codingcompetitions.withgoogle.com/kickstart/)
+  - Competitive Coding contest conducted by Google
+  - One round every month, featuring 3 questions 
+  - The questions are based on applying general competitive concepts. Analysis of questions give great intuition on how to tackle the problems and think like a programmer. 


### PR DESCRIPTION
Google Kickstart is Google's basic competitive coding contest, more approachable for beginners as compared to contests such as Code Jam. 